### PR TITLE
Optimize MDet and MInv

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ Functions list (see in-code documentation for more detail)
 | `QMean` | Quadratic mean |
 | `Median` | Median |
 | `MDet` | Matrix determinant |
+| `Mgje` | Guass-Jordan Elimination |
+| `MAug` | Matrix augmented with Identity |
 | `MCof` | Matrix cofactors |
 | `MInv` | Matrix inverse |
 | `Dot` | Dot product |

--- a/README.md
+++ b/README.md
@@ -23,8 +23,7 @@ Functions list (see in-code documentation for more detail)
 | `QMean` | Quadratic mean |
 | `Median` | Median |
 | `MDet` | Matrix determinant |
-| `Mgje` | Guass-Jordan Elimination |
-| `MAug` | Matrix augmented with Identity |
+| `Mgje` | Matrix Gauss-Jordan Elimination |
 | `MCof` | Matrix cofactors |
 | `MInv` | Matrix inverse |
 | `Dot` | Dot product |

--- a/lib.ua
+++ b/lib.ua
@@ -22,35 +22,23 @@ Median ← ÷2/+⊏⊟⊃⌊⌈÷2-1⧻.⊏⍏.
 
 # -- Matrices/Vectors --
 
-# Matrix Determinant
-MDet ← |1 ⍣(
-  °(¤¤)
-| -∩×⊙::°[⊙⊙⊙∘]♭
-| -∩(/+/×≡↻)⊙⤙∘⊸¯°⊏°3⊸⧻
-| /+×≡(MDet⍉▽)⊙¤⊞≠.°⊏⍉:⍜▽¯⋯2°⊂
-)
-MSquarify ↚ ⍜△[.√⊢]
-# Matrix Cofactors
-MCof ← ⍥¯⊞≠.◿2°⊏MSquarify≡(MDet MSquarify≡⊡⊙¤⊚¬⊞↥°⊟)⊙¤⬚0∵°⊚⊚⊸=.
-# Augment Matrix with Identity
-MAug ← ≡⊂:⊞=.°⊏
 # ? SwappedRows Pivot 
 GaussEliminate‼ ↚ ∧(
   ⊢⍖⊸⌵⍜⊙↙×0⟜⊡⤚⊸⊙⍉
-  ⍜⊏⇌ ⊃⊙⊙∘(^!) ⊟⤙⊙⊙∘ ⊙(⊃⋅⊙∘(^!) ⍤.≥ε⊸⌵) ⟜⊡
-  ⊸⍜⊡(÷⊸⊡:)⤙∘
-  ⍜(°⊂↻|⊙-:⊸⊞×:⊙(⊡⤚⊃⋅∘⍉))⤙∘
+  ⍜⊏⇌ ⊃⊙⊙∘^! ⊟⤙⊙⊙∘ ⊙(⊃⋅⊙∘^! ⍤.≥ε⊸⌵) ⟜⊡
+  ⊸⍜⊡(÷⊸⊡:),
+  ⍜(°⊂↻|⊙-:⊸⊞×:⊙(⊡⤚⊃⋅∘⍉)),
 )°⊏
 # Matrix Determinant
 MDet ← ◌⍣GaussEliminate‼(⍥¯/≠⊙⋅⋅∘|×⊙⋅⋅∘)⊙0 ⊙1
-# Preform Gauss-Jordan Elimination
+# Perform Gauss-Jordan elimination
 Mgje ← ⍣GaussEliminate‼()()⟜Throw!"Elimination cannot be completed"
-
-MInvImpl ↚ ⍜⍉(↘÷2⊸⧻) ⍣Mgje⟜Throw!"Matrix has no inverse" MAug
-
+MInvImpl ↚ ⍜⍉(↘÷2⊸⧻) ⍣Mgje⟜Throw!"Matrix has no inverse" ≡⊂:⊞=.°⊏
 # Matrix Inverse
 MInv ← setinv(MInvImpl|MInvImpl)
-
+MSquarify ↚ ⍜△[.√⊢]
+# Matrix Cofactors
+MCof ← ⍥¯⊞≠.◿2°⊏MSquarify≡(MDet MSquarify≡⊡⊙¤⊚¬⊞↥°⊟)⊙¤⬚0∵°⊚⊚⊸=.
 # Dot product
 Dot ← /+×
 # Cross product

--- a/lib.ua
+++ b/lib.ua
@@ -19,12 +19,29 @@ Median ← ÷2/+⊏⊟⊃⌊⌈÷2-1⧻.⊏⍏.
 # -- Matrices/Vectors --
 
 # Matrix Determinant
-MDet ← |1 ⍣°(¤¤)(/+×≡(MDet⍉⊏)⊙¤⍜⬚0≡°⊚¬°⊏⍉:⍜▽¯⋯2°⊂)
+MDet ← |1 ⍣(
+  °(¤¤)
+| -∩×⊙::°[⊙⊙⊙∘]♭
+| -∩(/+/×≡↻)⊙⤙∘⊸¯°⊏°3⊸⧻
+| /+×≡(MDet⍉▽)⊙¤⊞≠.°⊏⍉:⍜▽¯⋯2°⊂
+)
 MSquarify ↚ ⍜△[.√⊢]
 # Matrix Cofactors
 MCof ← ⍥¯⊞≠.◿2°⊏MSquarify≡(MDet MSquarify≡⊡⊙¤⊚¬⊞↥°⊟)⊙¤⬚0∵°⊚⊚⊸=.
+# Augment Matrix with Identity
+MAug ← ≡⊂:⊞=.°⊏
+MInvImpl ↚ (
+  MAug
+  °⊏
+  ∧(
+    ⍜⊏⇌⊟⤙⊙⊙∘⊢⍖⌵⍜⊙↙×0⟜⊡⤚⊸⊙⍉
+    ⊸⍜⊡(÷⍤"Matrix has no inverse"⊸≠0⊸⊡:)⤙∘
+    ⍜(°⊂↻|⊙-:⊸⊞×:⊙(⊡⤚⊃⋅∘⍉))⤙∘
+  )
+  ⍜⍉(↘÷2⊸⧻)
+)
 # Matrix Inverse
-MInv ← ÷⊃(⍤"Matrix has no inverse"⊸≠0MDet|⍉MCof)
+MInv ← setinv(MInvImpl|MInvImpl)
 
 # Dot product
 Dot ← /+×

--- a/lib.ua
+++ b/lib.ua
@@ -3,6 +3,10 @@
 
 # Extract real
 R ↚ ◌°ℂ
+# Floating point epsilon
+ε ← 2.2204460492503131E-16
+# ? ErrorMsg
+Throw! ↚ ⍤^!0
 
 # -- Averages --
 
@@ -30,16 +34,20 @@ MSquarify ↚ ⍜△[.√⊢]
 MCof ← ⍥¯⊞≠.◿2°⊏MSquarify≡(MDet MSquarify≡⊡⊙¤⊚¬⊞↥°⊟)⊙¤⬚0∵°⊚⊚⊸=.
 # Augment Matrix with Identity
 MAug ← ≡⊂:⊞=.°⊏
-MInvImpl ↚ (
-  MAug
-  °⊏
-  ∧(
-    ⍜⊏⇌⊟⤙⊙⊙∘⊢⍖⌵⍜⊙↙×0⟜⊡⤚⊸⊙⍉
-    ⊸⍜⊡(÷⍤"Matrix has no inverse"⊸≠0⊸⊡:)⤙∘
-    ⍜(°⊂↻|⊙-:⊸⊞×:⊙(⊡⤚⊃⋅∘⍉))⤙∘
-  )
-  ⍜⍉(↘÷2⊸⧻)
-)
+# ? SwappedRows Pivot 
+GaussEliminate‼ ↚ ∧(
+  ⊢⍖⊸⌵⍜⊙↙×0⟜⊡⤚⊸⊙⍉
+  ⍜⊏⇌ ⊃⊙⊙∘(^!) ⊟⤙⊙⊙∘ ⊙(⊃⋅⊙∘(^!) ⍤.≥ε⊸⌵) ⟜⊡
+  ⊸⍜⊡(÷⊸⊡:)⤙∘
+  ⍜(°⊂↻|⊙-:⊸⊞×:⊙(⊡⤚⊃⋅∘⍉))⤙∘
+)°⊏
+# Matrix Determinant
+MDet ← ◌⍣GaussEliminate‼(⍥¯/≠⊙⋅⋅∘|×⊙⋅⋅∘)⊙0 ⊙1
+# Preform Gauss-Jordan Elimination
+Mgje ← ⍣GaussEliminate‼()()⟜Throw!"Elimination cannot be completed"
+
+MInvImpl ↚ ⍜⍉(↘÷2⊸⧻) ⍣Mgje⟜Throw!"Matrix has no inverse" MAug
+
 # Matrix Inverse
 MInv ← setinv(MInvImpl|MInvImpl)
 


### PR DESCRIPTION
For MDet, hard code 2x2 and 3x3 cases. Leads to ~4x speed up

For MInv, use Gaussian Elimination which is O(n^3) while the Determinant method was O(n!).
For context, the previous algorithm computed an 8x8 inverse in the same time as the new algorithm computed a 1000x1000 inverse (~20 seconds on the pad)